### PR TITLE
Point Postgres-enum readers at StrEnum.Npgsql.EntityFrameworkCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ That's it — EF Core can now read and write string enums.
 
 EF Core stores string enums in non-nullable string columns (`NVARCHAR(MAX)` in SQL Server, `TEXT` in Postgres).
 
-> If you'd like to store string enums as native Postgres enum types instead of `TEXT`, see [StrEnum.Npgsql](https://github.com/StrEnum/StrEnum.Npgsql/).
+> If you'd like to store string enums as native Postgres enum types instead of `TEXT`, see [StrEnum.Npgsql.EntityFrameworkCore](https://github.com/StrEnum/StrEnum.Npgsql.EntityFrameworkCore/).
 
 Running `dotnet ef migrations add Init` produces:
 


### PR DESCRIPTION
## Summary

- Updates the Migrations-section callout to point at the new EF-specific package, [StrEnum.Npgsql.EntityFrameworkCore](https://github.com/StrEnum/StrEnum.Npgsql.EntityFrameworkCore/), instead of the raw-driver `StrEnum.Npgsql` package.
- One-line README change.

## Test plan

- [x] Render the README and confirm the blockquote link resolves to the new repo